### PR TITLE
Add support for Pathe France site and generate additional calendars

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,13 +24,22 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Update EN calendar
-        run: ./pathe_upcoming_movies.py --language EN --output ./calendars/PatheUpcomingMovies_EN.ics
+        run: ./pathe_upcoming_movies.py --country CH --language EN --output ./calendars/PatheUpcomingMovies_EN.ics
 
       - name: Update FR calendar
-        run: ./pathe_upcoming_movies.py --language FR --output ./calendars/PatheUpcomingMovies_FR.ics
+        run: ./pathe_upcoming_movies.py --country CH --language FR --output ./calendars/PatheUpcomingMovies_FR.ics
 
       - name: Update DE calendar
-        run: ./pathe_upcoming_movies.py --language DE --output ./calendars/PatheUpcomingMovies_DE.ics
+        run: ./pathe_upcoming_movies.py --country CH --language DE --output ./calendars/PatheUpcomingMovies_DE.ics
+
+      - name: Update EN calendar (FR site)
+        run: ./pathe_upcoming_movies.py --country FR --language EN --output ./calendars/PatheUpcomingMovies_EN_FR.ics
+
+      - name: Update FR calendar (FR site)
+        run: ./pathe_upcoming_movies.py --country FR --language FR --output ./calendars/PatheUpcomingMovies_FR_FR.ics
+
+      - name: Update DE calendar (FR site)
+        run: ./pathe_upcoming_movies.py --country FR --language DE --output ./calendars/PatheUpcomingMovies_DE_FR.ics
 
       - name: Commit and push
         uses: EndBug/add-and-commit@v9

--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # PatheUpcomingMovies
 
-Subscribe to a calendar of new upcoming movies in Pathé (Suisse).
+Subscribe to a calendar of new upcoming movies in Pathé (Suisse or France).
 
-Create a calendar (ics) of new upcoming movies in Pathé (Suisse).
+Create a calendar (ics) of new upcoming movies in Pathé (Suisse or France).
 
 ## Subscribe
 
-You can directly subscribe to one of the three calendars available:
+You can directly subscribe to one of the three calendars available for Suisse (CH):
 * [PatheUpcomingMovies_EN.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_EN.ics)
   * Movie's details in English
 * [PatheUpcomingMovies_FR.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_FR.ics)
   * Movie's details in French
 * [PatheUpcomingMovies_DE.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_DE.ics)
+  * Movie's details in Deutsch
+
+Or subscribe to one of the three calendars available for France (FR):
+* [PatheUpcomingMovies_EN.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_EN_FR.ics)
+  * Movie's details in English
+* [PatheUpcomingMovies_FR.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_FR_FR.ics)
+  * Movie's details in French
+* [PatheUpcomingMovies_DE.ics](https://raw.githubusercontent.com/baptistecdr/PatheUpcomingMovies/main/calendars/PatheUpcomingMovies_DE_FR.ics)
   * Movie's details in Deutsch
 
 ## Run

--- a/pathe_upcoming_movies.py
+++ b/pathe_upcoming_movies.py
@@ -27,9 +27,20 @@ class Language(Enum):
     def values():
         return [l.value for l in Language]
 
+class Country(Enum):
+    CH = "ch"
+    FR = "fr"
 
-def get_shows(language: Language):
-    result = requests.get(f"https://www.pathe.ch/api/shows", params={
+    @staticmethod
+    def names():
+        return [c.name for c in Country]
+
+    @staticmethod
+    def values():
+        return [c.value for c in Country]
+
+def get_shows(country: Country,language: Language):
+    result = requests.get(f"https://www.pathe.{country.value}/api/shows", params={
         "language": language.value
     }, headers={
         "User-Agent": USER_AGENT,
@@ -38,8 +49,8 @@ def get_shows(language: Language):
     return result.json()["shows"]
 
 
-def get_show(slug: str, language: Language):
-    result = requests.get(f"https://www.pathe.ch/api/show/{slug}", params={
+def get_show(country: Country, slug: str, language: Language):
+    result = requests.get(f"https://www.pathe.{country.value}/api/show/{slug}", params={
         "language": language.value
     }, headers={
         "User-Agent": USER_AGENT,
@@ -48,20 +59,26 @@ def get_show(slug: str, language: Language):
     return result.json()
 
 
-def create_event(show, language: Language, begin_time: datetime.time, end_time: datetime.time, timezone: ZoneInfo):
+def create_event(show, country: Country, language: Language, begin_time: datetime.time, end_time: datetime.time, timezone: ZoneInfo):
     slug = show["slug"]
-    release_at = datetime.strptime(show["releaseAt"]["CH_FR"], "%Y-%m-%d").date()
+
+    # Release date key format: CH_FR, FR_FR, etc.
+    release_key = f"{country.name}_FR"
+    release_at = datetime.strptime(show["releaseAt"][release_key], "%Y-%m-%d").date()
+
     event = Event()
     event.name = show["title"]
     event.description = show["synopsis"]
     event.begin = datetime.combine(release_at, begin_time, timezone)
     event.end = datetime.combine(release_at, end_time, timezone)
+
+    # URL pattern varies by country + language
     if language == Language.EN:
-        event.url = f"https://www.pathe.ch/en/movies-events/{slug}"
+        event.url = f"https://www.pathe.{country.value}/en/movies-events/{slug}"
     elif language == Language.FR:
-        event.url = f"https://www.pathe.ch/fr/films-evenements/{slug}"
+        event.url = f"https://www.pathe.{country.value}/fr/films-evenements/{slug}"
     elif language == Language.DE:
-        event.url = f"https://www.pathe.ch/en/filme-events/{slug}"
+        event.url = f"https://www.pathe.{country.value}/de/filme-events/{slug}"
     return event
 
 
@@ -81,6 +98,7 @@ def validate_timezone(timezone):
 
 if __name__ == '__main__':
     args_parser = ArgumentParser()
+    args_parser.add_argument("-c", "--country", help="Country code (CH or FR)", choices=Country.names(), required=True)
     args_parser.add_argument("-l", "--language", help="Language of movie's information", choices=Language.names(),
                              required=True)
     args_parser.add_argument("-o", "--output", help="Path to write the calendar", required=True)
@@ -95,6 +113,7 @@ if __name__ == '__main__':
                              default=DEFAULT_TIMEZONE)
     args = vars(args_parser.parse_args())
 
+    country = Country[args["country"]]
     language = Language[args["language"]]
     output = args["output"]
     begin_time = args["begin_time"]
@@ -102,11 +121,11 @@ if __name__ == '__main__':
     timezone = args["timezone"]
 
     calendar = Calendar()
-    shows = get_shows(language)
+    shows = get_shows(country, language)
     for show in shows:
         slug = show["slug"]
-        show = get_show(slug, language)
-        event = create_event(show, language, begin_time, end_time, timezone)
+        show = get_show(country, slug, language)
+        event = create_event(show, country, language, begin_time, end_time, timezone)
         calendar.events.add(event)
 
     with open(output, "w") as f:


### PR DESCRIPTION
Hi there,

First of all, thanks for sharing such a clean and understandable script! I wanted something similar for Pathe France, and reading through your code made it easy for me to jump in.

I ended up contributing my first open-source change thanks to your work. This PR introduces support for the French site (pathe.fr) while keeping the original Swiss calendars intact.

Key updates in this PR:

Introduced a new --country parameter to dynamically fetch movie data from either Pathe Switzerland (ch) or Pathe France (fr).

Updated the workflow to generate 3 additional ICS calendar files for the French site, one for each language (EN, FR, DE).

Ensures backward compatibility with existing Swiss site calendars.

No code duplication; all language variations are handled via parameters.

Hope this addition can be useful to others too!

Cheers,
Cécile